### PR TITLE
Fixed error with args and UTC if statment

### DIFF
--- a/timeBot.py
+++ b/timeBot.py
@@ -41,7 +41,7 @@ class TimeBot(BotPlugin):
         """
         if not args:
             return 'Am I supposed to guess the location?...'
-        if str.lower(args) == 'UTC':
+        if unicode.lower(args[0]) == 'utc':
             tz_name = 'UTC'
         else:
             city = '_'.join([word.capitalize() for word in args])


### PR DESCRIPTION
I was doing something funny on my test box, when I moved this to production machine it was failing because of the following error.

"descriptor 'lower' requires a 'str' object but received a 'list'"
