### PR TITLE
bugfix -   version2array not exists   

### DIFF
--- a/timeBot.py
+++ b/timeBot.py
@@ -2,8 +2,10 @@ import datetime, pytz
 import re
 
 # Backward compatibility
+def version2array(version):
+    return list(map(int,version.split('.',2)))
+
 from errbot.version import VERSION
-from errbot.utils import version2array
 if version2array(VERSION) >= [1,6,0]:
     from errbot import botcmd, BotPlugin
 else:


### PR DESCRIPTION
version2array is  removed from 6.0

but use version2tuple will break errbot instance < 6.0,  so i just  create a simple version2array  for back-compatibility.  hope it is good enough.